### PR TITLE
記事一覧の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,8 @@
+module Api::V1
+  class ArticlesController < BaseApiController
+    def index
+      articles = Article.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  RSpec.describe "Api::V1::Articles", type: :request do
+    describe "GET /api/v1/articles" do
+      subject { get(api_v1_articles_path) }
+      let!(:article1) { create(:article, updated_at: 1.days.ago) }
+      let!(:article2) { create(:article, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article) }
+      it "記事の一覧が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+        expect(response).to have_http_status(200)
+      end
+    end
+  end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -1,20 +1,20 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Articles", type: :request do
-  RSpec.describe "Api::V1::Articles", type: :request do
-    describe "GET /api/v1/articles" do
-      subject { get(api_v1_articles_path) }
-      let!(:article1) { create(:article, updated_at: 1.days.ago) }
-      let!(:article2) { create(:article, updated_at: 2.days.ago) }
-      let!(:article3) { create(:article) }
-      it "記事の一覧が取得できる" do
-        subject
-        res = JSON.parse(response.body)
-        expect(res.length).to eq 3
-        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-        expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
-        expect(res[0]["user"].keys).to eq ["id", "name", "email"]
-        expect(response).to have_http_status(200)
-      end
+  describe "GET /api/v1/articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+    it "記事の一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      expect(response).to have_http_status(:ok)
     end
   end
+end


### PR DESCRIPTION
## 概要
 - `active_model_serializer` を使って、記事の一覧を json で返す機能とテストを実装

## 内容
 - 記事一覧とユーザーのシリアライザーを作成
 - 記事一覧を返す API（index アクション） 及びテストの実装

## 補足
 - 記事一覧とその他の処理の API に関してはレスポンスの内容を分けたいので、別のシリアライザーを用意する