### PR TITLE
記事作成の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -9,5 +9,15 @@ module Api::V1
       article = Article.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+	def current_user
+    @current_user ||= User.first
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -43,4 +43,31 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "POST /api/v1/articles" do
+    subject { post(api_v1_articles_path, params: params) }
+
+    context "適切なパラメータを送信したとき" do
+      let(:params) { { article: attributes_for(:article) } }
+      let(:current_user) { create(:user) }
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+      fit "記事が作成される" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["user"]["id"]).to eq current_user.id
+      end
+    end
+
+    context "不適切なパラメータを送信したとき" do
+      let(:params) { attributes_for(:article) }
+      let(:current_user) { create(:user) }
+
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+      fit "エラーする" do
+        expect{ subject }.to raise_error ActionController::ParameterMissing     end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 - 記事作成の API とテストの実装
      --ダミーのcurrent_userメソッドを定義する
テストにスタブを定義する

## 内容
 - ダミーとして base_api_controller に current_user メソッドを定義して、仮実装として「 users テーブルの一番初めのユーザー」を引用
 - 新規作成する記事の user_id が current_user の id になるような API を実装
 - 仮実装である base_api_controller の current_user をテストのときだけ別の値として参照する（スタブという）ように実装

## 補足
 - テストで allow_any_instance_of メソッドを使用して current_user を呼び出せるように実装
 - stub の部分が rubocop で指摘されるのだが、この後のタスクで入れ替えてしまうので無視する