### PR TITLE
記事更新の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -15,7 +15,14 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def update
+      article = current_user.articles.find(params[:id])
+      article.update!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
     private
+
       def article_params
         params.require(:article).permit(:title, :body)
       end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-	def current_user
+  def current_user
     @current_user ||= User.first
   end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       let(:current_user) { create(:user) }
       before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
 
-      fit "記事が作成される" do
+      it "記事が作成される" do
         expect { subject }.to change { Article.count }.by(1)
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title]
@@ -66,8 +66,29 @@ RSpec.describe "Api::V1::Articles", type: :request do
       let(:current_user) { create(:user) }
 
       before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-      fit "エラーする" do
-        expect{ subject }.to raise_error ActionController::ParameterMissing     end
+
+      it "エラーする" do
+        expect { subject }.to raise_error ActionController::ParameterMissing
+      end
+    end
+  end
+
+  describe "PATCH /api/v1/articles/:id" do
+    subject { patch(api_v1_article_path(article_id), params: params) }
+
+    context "記事を更新するとき" do
+      let(:params) { { article: { title: "foo", created_at: 1.day.ago } } }
+      let(:article_id) { article.id }
+      let(:article) { create(:article, user: current_user) }
+      let(:current_user) { create(:user) }
+
+      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+      it "適切な値のみ更新される" do
+        expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
+                              not_change { article.reload.body } &
+                              not_change { article.reload.created_at }
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
+  RSpec::Matchers.define_negated_matcher :not_change, :change
   config.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
   end


### PR DESCRIPTION
## 概要
 - 記事更新に関する API と テストの実装
    -- stub の実装は記事作成の時と同様

## 内容
 - 更新する記事の user_id が current_user の id になるような API を実装
 - `not_change`マッチャをカスタム
 - 送信した値のみ更新され、書き換えを許していない値はそのままであることをテスト