### PR TITLE
記事削除の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -21,6 +21,11 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def destroy
+      article = current_user.articles.find(params[:id])
+      article.destroy!
+    end
+
     private
 
       def article_params

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -91,4 +91,28 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "DELETE /api/v1/articles/:id" do
+    subject { delete(api_v1_article_path(article.id)) }
+
+    let(:current_user) { create(:user) }
+    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+
+    context "自分の記事を削除しようとするとき" do
+      let!(:article) { create(:article, user: current_user) }
+      it "記事のレコードが削除される" do
+        expect { subject }.to change { Article.count }.by(-1)
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "他人が所持している記事のレコードを削除しようとするとき" do
+      let!(:article) { create(:article, user: other_user) }
+      let(:other_user) { create(:user) }
+      it "記事のレコードが削除できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound) &
+                              change { Article.count }.by(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 - 削除する記事の user_id が current_user の id になるような API を実装
 - stub を使って、テストの実装
 