### PR TITLE
新規登録 API とテストの実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+  private
+
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
+
+    def account_update_params
+      params.permit(:name, :email)
+    end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,6 @@ module Uiita
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
   end
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -6,15 +6,16 @@ DeviseTokenAuth.setup do |config|
   # this to false to prevent the Authorization header from changing after
   # each request.
   # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
   # to 31. It is recommended to not use a value more than 10 in other environments.
-  config.token_cost = Rails.env.test? ? 4 : 10
+  # config.token_cost = Rails.env.test? ? 4 : 10
 
   # Sets the max number of concurrent devices per user, which is 10 by default.
   # After this limit is reached, the oldest tokens will be removed.
@@ -47,6 +48,12 @@ DeviseTokenAuth.setup do |config|
   #                        :'expiry' => 'expiry',
   #                        :'uid' => 'uid',
   #                        :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                            client: "client",
+                            expiry: "expiry",
+                            uid: "uid",
+                            'token-type': "token-type" }
+
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth",  controllers: {
+        registrations: "api/v1/auth/registrations"
+      }
+
       resources :articles
     end
   end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "必要な情報が存在するとき" do
+      let(:params) { attributes_for(:user) }
+      it "ユーザーの新規登録ができる" do
+        expect { subject }.to change { User.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res["data"]["email"]).to eq User.last.email
+      end
+
+      it "header 情報を取得することができる" do
+        subject
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
+      end
+    end
+
+    context "name が存在しないとき" do
+      let(:params) { attributes_for(:user, name: nil) }
+      it "エラーする" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]["name"]).to include "can't be blank"
+      end
+    end
+
+    context "email が存在しないとき" do
+      let(:params) { attributes_for(:user, email: nil) }
+      it "エラーする" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]["email"]).to include "can't be blank"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "password が存在しないとき" do
+      let(:params) { attributes_for(:user, password: nil) }
+      it "エラーする" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["errors"]["password"]).to include "can't be blank"
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 内容
 -` bundle exec rails g controller api/v1/auth/registrations` コマンドで新規登録API を実装するコントローラーの作成・API実装
  >name カラムを既存メソッドに付与したいため、devise_token_auth のメソッドをオーバーライドする
 - routes.rb の修正
 - 新規登録時にレスポンスとして返される header 情報の設定(config/initializers/devise_token_auth.rb)
 - Postman で処理が通るか確認
 - ユーザーの新規登録ができたときに、ヘッダー情報が取得できることをポイントにして、テストを実装