### PR TITLE
Feature/api/fix api

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 module Api::V1
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
 
   has_many :articles, dependent: :destroy

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -49,11 +49,10 @@ DeviseTokenAuth.setup do |config|
   #                        :'uid' => 'uid',
   #                        :'token-type' => 'token-type' }
   config.headers_names = { 'access-token': "access-token",
-                            client: "client",
-                            expiry: "expiry",
-                            uid: "uid",
-                            'token-type': "token-type" }
-
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth",  controllers: {
-        registrations: "api/v1/auth/registrations"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations",
       }
 
       resources :articles

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -45,13 +45,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     context "適切なパラメータを送信したとき" do
       let(:params) { { article: attributes_for(:article) } }
       let(:current_user) { create(:user) }
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-
+      let(:headers) { current_user.create_new_auth_token }
       it "記事が作成される" do
         expect { subject }.to change { Article.count }.by(1)
         res = JSON.parse(response.body)
@@ -64,9 +63,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     context "不適切なパラメータを送信したとき" do
       let(:params) { attributes_for(:article) }
       let(:current_user) { create(:user) }
-
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-
+      let(:headers) { current_user.create_new_auth_token }
       it "エラーする" do
         expect { subject }.to raise_error ActionController::ParameterMissing
       end
@@ -74,16 +71,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article_id), params: params) }
+    subject { patch(api_v1_article_path(article_id), params: params, headers: headers) }
 
     context "記事を更新するとき" do
       let(:params) { { article: { title: "foo", created_at: 1.day.ago } } }
       let(:article_id) { article.id }
       let(:article) { create(:article, user: current_user) }
       let(:current_user) { create(:user) }
-
-      before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
-
+      let(:headers) { current_user.create_new_auth_token }
       it "適切な値のみ更新される" do
         expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
                               not_change { article.reload.body } &
@@ -93,10 +88,10 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事を削除しようとするとき" do
       let!(:article) { create(:article, user: current_user) }


### PR DESCRIPTION
## 概要
 - stub で作った仮実装を devise_token_auth の機能を反映した内容に修正

## 内容
 - devise_token_auth のヘルパーメソッドをエイリアスを指定してそれぞれ反映
 - articles_controller 特定の API を認証済のユーザー以外はアクセスできないようにする
 - 上記内容をふまえて、spec ファイルを修正