### PR TITLE
 Article model に下書き機能を追加

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -24,4 +25,6 @@ class Article < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :body, presence: true
+
+  enum status: { draft: "draft", published: "published" }
 end

--- a/db/migrate/20210629232559_add_status_to_articles.rb
+++ b/db/migrate/20210629232559_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :status, :string, default: "draft"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_29_063914) do
+ActiveRecord::Schema.define(version: 2021_06_29_232559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 2021_06_29_063914) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "status", default: "draft"
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -22,5 +23,12 @@ FactoryBot.define do
     title { Faker::Lorem.sentence }
     body { Faker::Lorem.sentence }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -20,8 +20,6 @@
 #
 require "rails_helper"
 
-require "rails_helper"
-
 RSpec.describe Article, type: :model do
   context "記事のタイトルと本文が入力されているとき" do
     let(:article) { build(:article) }

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default("draft")
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -19,39 +20,54 @@
 #
 require "rails_helper"
 
+require "rails_helper"
+
 RSpec.describe Article, type: :model do
-  context "記事の title, body が指定されているとき" do
-    let(:user) { build(:user) }
-    let(:article) { build(:article, user: user) }
-    it "記事が投稿できる" do
+  context "記事のタイトルと本文が入力されているとき" do
+    let(:article) { build(:article) }
+    it "下書き状態の記事が作成できる" do
       expect(article).to be_valid
+      expect(article[:status]).to eq "draft"
     end
   end
 
-  context "title が指定されていない時" do
-    let(:user) { build(:user) }
+  context "status が下書き状態のとき" do
+    let(:article) { build(:article, :draft) }
+    it "記事を下書き状態で作成できる" do
+      expect(article).to be_valid
+      expect(article[:status]).to eq "draft"
+    end
+  end
+
+  context "status が公開状態のとき" do
+    let(:article) { build(:article, :published) }
+    it "記事を公開状態で作成できる" do
+      expect(article).to be_valid
+      expect(article[:status]).to eq "published"
+    end
+  end
+
+  context "記事の title が指定されていないとき" do
     let(:article) { build(:article, title: nil) }
-    it "記事の投稿に失敗する" do
+    it "記事が投稿できない" do
       expect(article).to be_invalid
-      expect(article.errors.details[:title][0][:error]).to eq :blank
+      expect(article.errors.messages[:title]).to eq ["can't be blank"]
     end
   end
 
-  context "body が指定されていない時" do
-    let(:user) { build(:user) }
+  context "記事の body が指定されていないとき" do
     let(:article) { build(:article, body: nil) }
-    it "記事の投稿に失敗する" do
+    it "記事が投稿できない" do
       expect(article).to be_invalid
-      expect(article.errors.details[:body][0][:error]).to eq :blank
+      expect(article.errors.messages[:body]).to eq ["can't be blank"]
     end
   end
 
-  context "title の文字数が51文字以上の時" do
-    let(:user) { build(:user) }
+  context "記事の title の最大文字数が51文字以上のとき" do
     let(:article) { build(:article, title: "a" * 51) }
-    it "記事の投稿に失敗する" do
+    it "記事が投稿できない" do
       expect(article).to be_invalid
-      expect(article.errors.details[:title][0][:error]).to eq :too_long
+      expect(article.errors.messages[:title]).to eq ["is too long (maximum is 50 characters)"]
     end
   end
 end


### PR DESCRIPTION
## 内容
 - Article テーブルに` status` カラムの追加
   - `status` カラムのでファオルトの状態を下書きにする
 - article model に `enum` を使って、記事の状態に関する記述を追加
 - `trait`を用いて、テストで FctoryBot 使用時の記述短縮
 - model のテスト実装
 - 記事の下書き機能を実装
   - 一覧に下書き記事は表示されない
   - 記事の詳細は記事の所持者にかかわらず、公開された状態にならないと閲覧できない
   - 作成 / 更新時に記事公開のステータスを任意の値に変更できるように調整