### PR TITLE
Feature/fix/article draft

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,12 +2,12 @@ module Api::V1
   class ArticlesController < BaseApiController
     before_action :authenticate_user!, only: [:create, :update, :destroy]
     def index
-      articles = Article.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
@@ -30,7 +30,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :updated_at
+  attributes :id, :title, :updated_at, :status
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user, serializer: Api::V1::UserSerializer
 end


### PR DESCRIPTION
 ## 概要
 - 記事に状態を含めた内容を API とテストに反映する
   - 既存の serializer の調整

## 内容
 - serializer を修正して、レスポンスに記事の状態を含める。
 - 公開されている記事だけ取得できるように API を修正する
 - 記事を作成する場合は、記事の公開/非公開を選択できるようにストロングパラメータに `status` を追加
 - 記事の API に関するテストを修正