### PR TITLE
下書き記事の一覧・詳細 のAPI実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,15 +1,15 @@
 module Api::V1
-	class Articles::DraftsController < BaseApiController
-		before_action :authenticate_user!, only: [:index, :show]
+  class Articles::DraftsController < BaseApiController
+    before_action :authenticate_user!, only: [:index, :show]
 
-		def index
-			articles = current_user.articles.draft.order(updated_at: :desc)
-			render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
-		end
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
 
-		def show
+    def show
       article = current_user.articles.draft.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
-	end
+  end
 end

--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,15 @@
+module Api::V1
+	class Articles::DraftsController < BaseApiController
+		before_action :authenticate_user!, only: [:index, :show]
+
+		def index
+			articles = current_user.articles.draft.order(updated_at: :desc)
+			render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+		end
+
+		def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+	end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
 
       resources :articles
     end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  let(:headers) { current_user.create_new_auth_token }
+  let(:current_user) { create(:user) }
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    let!(:article1) { create(:article, :draft, user: current_user, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :draft, user: current_user, updated_at: 3.days.ago) }
+    let!(:article3) { create(:article, :draft, user: current_user) }
+    let!(:article4) { create(:article, :published, user: current_user) }
+    let!(:article5) { create(:article, :draft) }
+    fit "自分が書いた下書きの一覧のみが取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq 3
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "status", "user"]
+    end
+  end
+
+  describe "GET /api/v1/articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article.id), headers: headers) }
+
+    context "指定した id の記事が存在して" do
+      context "対象の記事が自分が書いた下書き記事のとき" do
+        let(:article) { create(:article, :draft, user: current_user) }
+        fit "記事の詳細を取得できる" do
+          subject
+          res = JSON.parse(response.body)
+          expect(res["id"]).to eq article.id
+          expect(res["title"]).to eq article.title
+          expect(res["body"]).to eq article.body
+          expect(res["status"]).to eq article.status
+          expect(res["updated_at"]).to be_present
+          expect(res["user"]["id"]).to eq article.user.id
+          expect(response).to have_http_status(:ok)
+          expect(res["user"].keys).to eq ["id", "name", "email"]
+        end
+      end
+
+      context "対象の記事が他のユーザーが書いた下書き記事のとき" do
+        let(:article) { create(:article, :draft) }
+        fit "エラーする" do
+          expect { subject }.to raise_error ActiveRecord::RecordNotFound
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
     let!(:article3) { create(:article, :draft, user: current_user) }
     let!(:article4) { create(:article, :published, user: current_user) }
     let!(:article5) { create(:article, :draft) }
-    fit "自分が書いた下書きの一覧のみが取得できる" do
+    it "自分が書いた下書きの一覧のみが取得できる" do
       subject
       res = JSON.parse(response.body)
       expect(response).to have_http_status(:ok)
@@ -27,7 +27,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
     context "指定した id の記事が存在して" do
       context "対象の記事が自分が書いた下書き記事のとき" do
         let(:article) { create(:article, :draft, user: current_user) }
-        fit "記事の詳細を取得できる" do
+        it "記事の詳細を取得できる" do
           subject
           res = JSON.parse(response.body)
           expect(res["id"]).to eq article.id
@@ -43,7 +43,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
 
       context "対象の記事が他のユーザーが書いた下書き記事のとき" do
         let(:article) { create(:article, :draft) }
-        fit "エラーする" do
+        it "エラーする" do
           expect { subject }.to raise_error ActiveRecord::RecordNotFound
         end
       end


### PR DESCRIPTION
## 概要
 - 記事の下書き一覧と詳細を取得する API とテストの実装

## 内容
 - endpoint の設定
   - index:  `/api/v1/articles/draft`
   - show:  `/api/v1/articles/draft/:id`
 - 下書き記事の一覧/詳細の API の作成
 - 下書き記事の一覧/詳細 の API に関するテストの実装