### PR TITLE
コメント機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,7 +8,7 @@ module Api::V1
 
     def show
       article = Article.published.find(params[:id])
-      render json: article, serializer: Api::V1::ArticleSerializer
+      render json: article, serializer: Api::V1::CommentSerializer
     end
 
     def create

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,7 +8,7 @@ module Api::V1
 
     def show
       article = Article.published.find(params[:id])
-      render json: article, serializer: Api::V1::CommentSerializer
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def create

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,16 @@
+module Api::V1
+  class CommentsController < BaseApiController
+    before_action :authenticate_user!, only: [:create]
+    def create
+      article = Article.find(params["comment"]["article_id"])
+      comment = current_user.comments.create!(comment_params)
+      render json: comment, serializer: Api::V1::CommentSerializer
+    end
+
+    private
+
+      def comment_params
+        params.require(:comment).permit(:body, :article_id)
+      end
+  end
+end

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -2,7 +2,7 @@ module Api::V1
   class CommentsController < BaseApiController
     before_action :authenticate_user!, only: [:create]
     def create
-      article = Article.find(params["comment"]["article_id"])
+      Article.find(params["comment"]["article_id"])
       comment = current_user.comments.create!(comment_params)
       render json: comment, serializer: Api::V1::CommentSerializer
     end

--- a/app/serializers/api/v1/comment_serializer.rb
+++ b/app/serializers/api/v1/comment_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::CommentSerializer < ActiveModel::Serializer
+  attributes :id, :body
+  belongs_to :article, serializer: Api::V1::ArticleSerializer
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      resources :comments, only: [:create]
+
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Api::V1::Comments", type: :request do
     let(:headers) { current_user.create_new_auth_token }
     context "コメントと記事の id が指定されているとき" do
       let(:params) { { comment: attributes_for(:comment, user: current_user, article_id: article.id) } }
-      fit "コメントが投稿できる" do
+      it "コメントが投稿できる" do
         expect { subject }.to change { Comment.count }.by(1)
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
@@ -21,14 +21,14 @@ RSpec.describe "Api::V1::Comments", type: :request do
 
     context "コメントが入力されていないとき" do
       let(:params) { { comment: attributes_for(:comment, body: nil, user: current_user, article_id: article.id) } }
-      fit "コメントが投稿できない" do
+      it "コメントが投稿できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 
     context "記事の id が存在しないとき" do
       let(:params) { { comment: attributes_for(:comment, user: current_user, article_id: nil) } }
-      fit "コメントが投稿できない" do
+      it "コメントが投稿できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Api::V1::Comments", type: :request do
     let(:headers) { current_user.create_new_auth_token }
     context "コメントと記事の id が指定されているとき" do
       let(:params) { { comment: attributes_for(:comment, user: current_user, article_id: article.id) } }
-      it "コメントが投稿できる" do
+      fit "コメントが投稿できる" do
         expect { subject }.to change { Comment.count }.by(1)
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
@@ -21,14 +21,14 @@ RSpec.describe "Api::V1::Comments", type: :request do
 
     context "コメントが入力されていないとき" do
       let(:params) { { comment: attributes_for(:comment, body: nil, user: current_user, article_id: article.id) } }
-      it "コメントが投稿できない" do
+      fit "コメントが投稿できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 
     context "記事の id が存在しないとき" do
       let(:params) { { comment: attributes_for(:comment, user: current_user, article_id: nil) } }
-      it "コメントが投稿できない" do
+      fit "コメントが投稿できない" do
         expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Comments", type: :request do
+  describe "POST /api/v1/comments" do
+    subject { post(api_v1_comments_path, params: params, headers: headers) }
+
+    let(:article) { create(:article) }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+    context "コメントと記事の id が指定されているとき" do
+      let(:params) { { comment: attributes_for(:comment, user: current_user, article_id: article.id) } }
+      it "コメントが投稿できる" do
+        expect { subject }.to change { Comment.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res["body"]).to eq params[:comment][:body]
+        expect(res["user"]["id"]).to eq current_user.id
+        expect(res["article"]["id"]).to eq params[:comment][:article_id]
+      end
+    end
+
+    context "コメントが入力されていないとき" do
+      let(:params) { { comment: attributes_for(:comment, body: nil, user: current_user, article_id: article.id) } }
+      it "コメントが投稿できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "記事の id が存在しないとき" do
+      let(:params) { { comment: attributes_for(:comment, user: current_user, article_id: nil) } }
+      it "コメントが投稿できない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
- コメント投稿の API と テストの実装

## 内容
 - コメントに関する `serializer` の作成
 - 投稿するコメントの user_id が current_user の id になるような API を実装