### PR TITLE
記事のいいね機能の実装

### DIFF
--- a/app/controllers/api/v1/article_likes_controller.rb
+++ b/app/controllers/api/v1/article_likes_controller.rb
@@ -1,0 +1,17 @@
+module Api::V1
+  class ArticleLikesController < BaseApiController
+    before_action :authenticate_user!, only: [:create]
+
+    def create
+      Article.find(params["article_like"]["article_id"])
+      article_like = current_user.article_likes.create!(article_like_params)
+      render json: article_like, serializer: Api::V1::ArticleLikesSerializer
+    end
+
+    private
+
+      def article_like_params
+        params.require(:article_like).permit(:article_id)
+      end
+  end
+end

--- a/app/controllers/api/v1/article_likes_controller.rb
+++ b/app/controllers/api/v1/article_likes_controller.rb
@@ -1,11 +1,16 @@
 module Api::V1
   class ArticleLikesController < BaseApiController
-    before_action :authenticate_user!, only: [:create]
+    before_action :authenticate_user!, only: [:create, :destroy]
 
     def create
       Article.find(params["article_like"]["article_id"])
       article_like = current_user.article_likes.create!(article_like_params)
       render json: article_like, serializer: Api::V1::ArticleLikesSerializer
+    end
+
+    def destroy
+      article_like = current_user.article_likes.find(params[:id])
+      article_like.destroy!
     end
 
     private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -22,6 +22,7 @@ class Article < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+  has_many :liked_users, through: :article_likes, source: :user
 
   validates :title, presence: true, length: { maximum: 50 }
   validates :body, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,5 +42,6 @@ class User < ApplicationRecord
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
+  has_many :liked_posts, through: :article_likes, source: :post
   validates :name, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 30 }
 end

--- a/app/serializers/api/v1/article_likes_serializer.rb
+++ b/app/serializers/api/v1/article_likes_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::ArticleLikesSerializer < ActiveModel::Serializer
+  attributes :id
+  belongs_to :article, serializer: Api::V1::ArticleSerializer
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,7 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  # config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,12 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      resources :article_likes, only: [:create, :destroy]
+
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
       resources :comments, only: [:create]
-      resources :article_likes, only: [:create]
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
         registrations: "api/v1/auth/registrations",
       }
       resources :comments, only: [:create]
-
+      resources :article_likes, only: [:create]
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end

--- a/spec/requests/api/v1/article_likes_spec.rb
+++ b/spec/requests/api/v1/article_likes_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::ArticleLikes", type: :request do
+  describe "POST /api/v1/article_likes" do
+    subject { post(api_v1_article_likes_path, params: params, headers: headers) }
+
+    let(:article) { create(:article) }
+    let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    context "記事の id が存在するとき" do
+      let(:params) { { article_like: attributes_for(:article_like, user: current_user, article_id: article.id) } }
+
+      it "いいねできる" do
+        expect { subject }.to change { ArticleLike.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res["article"]["id"]).to eq params[:article_like][:article_id]
+        expect(res["user"]["id"]).to eq current_user.id
+      end
+    end
+
+    context "記事の id が存在しないとき" do
+      let(:params) { { article_like: attributes_for(:article_like, user: current_user, article_id: nil) } }
+
+      it "いいねできない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
 - 記事のいいね機能の API とテストの実装

## 内容
 - `Api::V1::ArticleLikeSerializer` の作成
 - `index` と `destroy` メソッドが映える様にルーティングを調整
 - article_likes コントローラーに `index`アクションと `destroy`アクションを実装
 - request テストの実装