### PR TITLE
記事の検索・ソート機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -27,6 +27,18 @@ module Api::V1
       article.destroy!
     end
 
+    def search
+      # フォームで入力された、キーワードをパラメータで取得
+      keyword = params[:keyword]
+
+      # || は、左辺を評価して false だから、右辺を評価した。つまり、渡ってきた sort のパラメータの値が nil の場合、created_at desc をデフォとする。
+      sort = params[:sort] || "created_at DESC"
+
+      # 入力された値をLIKE 句により各カラムと一致したものを抽出する。
+      articles = Article.published.where("title LIKE(?) or body LIKE(?)", "%#{keyword}%", "%#{keyword}%").order(sort)
+      render json: articles, each_serializer: Api::V1::ArticleSerializer
+    end
+
     private
 
       def article_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,23 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      resources :articles do
+        collection do
+          get "search"
+        end
+        resources :drafts, only: [:index, :show]
+      end
+
       resources :article_likes, only: [:create, :destroy]
 
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
       resources :comments, only: [:create]
-      namespace :articles do
-        resources :drafts, only: [:index, :show]
-      end
 
       namespace :current do
         resources :articles, only: [:index]
       end
-      resources :articles
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,14 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
+
       resources :articles do
         collection do
           get "search"
         end
-        resources :drafts, only: [:index, :show]
       end
 
       resources :article_likes, only: [:create, :destroy]

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -134,12 +134,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
     let!(:article3) { create(:article, :published, title: "xxx", body: "xxx", created_at: 3.days.ago) }
     context "キーワードを指定したとき" do
       let(:params) { { "keyword": "TT", "sort": "created_at DESC" } }
-      it "公開状態でタイトルまたは本文にキーワードを含まれている記事が作成順に一覧で取得できる" do
+      fit "公開状態でタイトルまたは本文にキーワードを含まれている記事が作成順に一覧で取得できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
         expect(res.length).to eq 2
-        expect(res[0]["title"]).to eq "TT"
         expect(res[0]["status"]).to eq "published"
         expect(res.map {|article| article["id"] }).to eq [article2.id, article1.id]
       end
@@ -147,7 +146,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context "キーワードが指定されていないとき" do
       let(:params) { { "keyword": nil, "sort": "created_at DESC" } }
-      it "全ての公開状態の記事の一覧が作成順で取得できる" do
+      fit "全ての公開状態の記事の一覧が作成順で取得できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -125,4 +125,36 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(response).to have_http_status(:no_content)
     end
   end
+
+  describe "GET /api/v1/articles/search" do
+    subject { get(search_api_v1_articles_path, params: params) }
+
+    let!(:article1) { create(:article, :published, title: "TT", created_at: 2.days.ago) }
+    let!(:article2) { create(:article, :published, body: "TTTT", created_at: 1.days.ago) }
+    let!(:article3) { create(:article, :published, title: "xxx", body: "xxx", created_at: 3.days.ago) }
+    context "キーワードを指定したとき" do
+      let(:params) { { "keyword": "TT", "sort": "created_at DESC" } }
+      it "公開状態でタイトルまたは本文にキーワードを含まれている記事が作成順に一覧で取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 2
+        expect(res[0]["title"]).to eq "TT"
+        expect(res[0]["status"]).to eq "published"
+        expect(res.map {|article| article["id"] }).to eq [article2.id, article1.id]
+      end
+    end
+
+    context "キーワードが指定されていないとき" do
+      let(:params) { { "keyword": nil, "sort": "created_at DESC" } }
+      it "全ての公開状態の記事の一覧が作成順で取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|article| article["id"] }).to eq [article2.id, article1.id, article3.id]
+        expect(res[0]["status"]).to eq "published"
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     let!(:article3) { create(:article, :published, title: "xxx", body: "xxx", created_at: 3.days.ago) }
     context "キーワードを指定したとき" do
       let(:params) { { "keyword": "TT", "sort": "created_at DESC" } }
-      fit "公開状態でタイトルまたは本文にキーワードを含まれている記事が作成順に一覧で取得できる" do
+      it "公開状態でタイトルまたは本文にキーワードを含まれている記事が作成順に一覧で取得できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)
@@ -146,7 +146,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     context "キーワードが指定されていないとき" do
       let(:params) { { "keyword": nil, "sort": "created_at DESC" } }
-      fit "全ての公開状態の記事の一覧が作成順で取得できる" do
+      it "全ての公開状態の記事の一覧が作成順で取得できる" do
         subject
         res = JSON.parse(response.body)
         expect(response).to have_http_status(:ok)


### PR DESCRIPTION
## 概要
 - 記事のキーワード検索機能の API とテストの実装
 - 新着順、いいね数順などのソート機能の API とテストの実装

## 補足
 - serializer を使って、JSON 形式でデータを取得する
 - フォームで入力された `keyword` と `sort` はパラメータで取得する
 - パラメータで取得した値をLIKE句により各カラムと一致したものを抽出する。