### PR TITLE
CORS の設定を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,12 @@ gem "puma", "~> 4.1"
 gem "rails", "~> 6.0.3", ">= 6.0.3.2"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 4.0"
+gem "rack-cors"
 
 group :development, :test do
   gem "factory_bot_rails"
   gem "faker"
-  gem "pry-byebug"
+  gem "pry-byebug
   gem "pry-doc"
   gem "pry-rails"
   gem "rspec-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -9,15 +9,15 @@ gem "config"
 gem "devise_token_auth"
 gem "pg"
 gem "puma", "~> 4.1"
+gem "rack-cors"
 gem "rails", "~> 6.0.3", ">= 6.0.3.2"
 gem "turbolinks", "~> 5"
 gem "webpacker", "~> 4.0"
-gem "rack-cors"
 
 group :development, :test do
   gem "factory_bot_rails"
   gem "faker"
-  gem "pry-byebug
+  gem "pry-byebug"
   gem "pry-doc"
   gem "pry-rails"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,6 +176,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -312,6 +314,7 @@ DEPENDENCIES
   pry-doc
   pry-rails
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-erd
   rspec-rails

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,16 +1,16 @@
 # Be sure to restart your server when you modify this file.
 
- # Avoid CORS issues when API is called from the frontend app.
- # Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+# Avoid CORS issues when API is called from the frontend app.
+# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
 
- # Read more: https://github.com/cyu/rack-cors
+# Read more: https://github.com/cyu/rack-cors
 
- Rails.application.config.middleware.insert_before 0, Rack::Cors do
-	allow do
-		origins Settings.frontend.url
-		resource "*",
-						 headers: :any,
-						 expose: ["access-token", "expiry", "token-type", "uid", "client"],
-						 methods: [:get, :post, :put, :patch, :delete, :options]
-	end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins Settings.frontend.url
+    resource "*",
+             headers: :any,
+             expose: ["access-token", "expiry", "token-type", "uid", "client"],
+             methods: [:get, :post, :put, :patch, :delete, :options]
+  end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,16 @@
+# Be sure to restart your server when you modify this file.
+
+ # Avoid CORS issues when API is called from the frontend app.
+ # Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin AJAX requests.
+
+ # Read more: https://github.com/cyu/rack-cors
+
+ Rails.application.config.middleware.insert_before 0, Rack::Cors do
+	allow do
+		origins Settings.frontend.url
+		resource "*",
+						 headers: :any,
+						 expose: ["access-token", "expiry", "token-type", "uid", "client"],
+						 methods: [:get, :post, :put, :patch, :delete, :options]
+	end
+end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,0 +1,2 @@
+frontend:
+  url: "http://localhost:8080"

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,0 +1,2 @@
+frontend:
+  url: "http://localhost:8080"


### PR DESCRIPTION
## 概要
 - フロントエンドからのアクセスを許可する為の設定

## 手順
 - #28 で導入した `Config` で作成したファイルに定数を書き込む
  (　`config/settings/development.yml` & `config/settings/test.yml`　)
 - Gemfile に `rack-cors` を追記して `bundle install`
 - Cors の設定を記述

## 補足
 - Cors で設定したルールが雑で何でもオッケーになっているので、本来はしっかり絞りこむ必要がある。