### PR TITLE
記事のコメント一覧を取得するAPI とテストの実装の修正

### DIFF
--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -2,13 +2,13 @@ module Api::V1
   class CommentsController < BaseApiController
     before_action :authenticate_user!, only: [:create]
     def index
-      article = Article.find(params["article"]["id"])
+      article = Article.published.find(params["comment"]["article_id"])
       comments = article.comments.order(created_at: :desc)
       render json: comments, each_serializer: Api::V1::CommentSerializer
     end
 
     def create
-      Article.find(params["comment"]["article_id"])
+      Article.published.find(params["comment"]["article_id"])
       comment = current_user.comments.create!(comment_params)
       render json: comment, serializer: Api::V1::CommentSerializer
     end
@@ -16,7 +16,7 @@ module Api::V1
     private
 
       def comment_params
-        params.require(:comment).permit(:body, :article_id)
+        params.require(:comment).permit(:body, :article_id, :created_at)
       end
   end
 end

--- a/app/serializers/api/v1/comment_serializer.rb
+++ b/app/serializers/api/v1/comment_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::CommentSerializer < ActiveModel::Serializer
-  attributes :id, :body
+  attributes :id, :body, :created_at
   belongs_to :article, serializer: Api::V1::ArticleSerializer
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      resources :comments, only: [:index, :create]
+
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
@@ -16,8 +18,6 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
-      resources :comments, only: [:index, :create]
-
       namespace :current do
         resources :articles, only: [:index]
       end

--- a/spec/requests/api/v1/comments_spec.rb
+++ b/spec/requests/api/v1/comments_spec.rb
@@ -1,10 +1,29 @@
 require "rails_helper"
 
 RSpec.describe "Api::V1::Comments", type: :request do
+  describe "GET /api/v1/comments" do
+    subject { get(api_v1_comments_path, params: params) }
+
+    let(:params) { { comment: attributes_for(:comment, article_id: article.id) } }
+    let(:article) { create(:article, :published) }
+    let!(:comment1) { create(:comment, article_id: article.id, created_at: 1.days.ago) }
+    let!(:comment2) { create(:comment, article_id: article.id) }
+    it "投稿順にコメントが一覧で取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 2
+      expect(response).to have_http_status(:ok)
+      expect(res.map {|comment| comment["id"] }).to eq [comment2.id, comment1.id]
+      expect(res[0]["article"]["id"]).to eq params[:comment][:article_id]
+      expect(res[0]["article"].keys).to eq ["id", "title", "body", "updated_at", "status"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+    end
+  end
+
   describe "POST /api/v1/comments" do
     subject { post(api_v1_comments_path, params: params, headers: headers) }
 
-    let(:article) { create(:article) }
+    let(:article) { create(:article, :published) }
     let(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
     context "コメントと記事の id が指定されているとき" do


### PR DESCRIPTION
## 内容
- comment serializer にcreated_at を追加
- 任意の記事に紐付けて、コメントの一覧を新着順で取得する API を実装
- テストの実装
 