### PR TITLE
ヘッダー部分のリンクの紐付け

### DIFF
--- a/front/layouts/default.vue
+++ b/front/layouts/default.vue
@@ -6,12 +6,18 @@
       </nuxt-link>
       <v-spacer></v-spacer>
       <template v-if="isSignedIn">
-        <v-btn text :class="$style.register">投稿する</v-btn>
+        <nuxt-link to="/">
+          <v-btn text :class="$style.register">投稿する</v-btn>
+        </nuxt-link>
         <v-btn text :class="$style.login" @click="signOut">ログアウト</v-btn>
       </template>
       <template v-else>
-        <v-btn text :class="$style.register">ユーザー登録</v-btn>
-        <v-btn text :class="$style.login">ログイン</v-btn>
+        <nuxt-link to="/sign_up">
+          <v-btn text :class="$style.register">ユーザー登録</v-btn>
+        </nuxt-link>
+        <nuxt-link to="/sign_in">
+          <v-btn text :class="$style.login">ログイン</v-btn>
+        </nuxt-link>
       </template>
     </v-app-bar>
     <v-main>


### PR DESCRIPTION
## 概要
- タイトルの通り

## 補足
- Nuxt.js では a タグは基本使用せずに nuxt-link を使う

## 参考
- [Nuxt.js では a タグは基本使用せずに nuxt-link を使う](https://www.soudegesu.com/post/javascript/nuxt-page-link/) 