### PR TITLE
認証前後のリダイレクト処理を実装 

### DIFF
--- a/front/middleware/authed.js
+++ b/front/middleware/authed.js
@@ -1,0 +1,6 @@
+export default function ({ store, redirect, route }) {
+  const isSingedIn = store.state.user.isSignedIn
+  if (!isSingedIn) {
+    return redirect('/sign_in')
+  }
+}

--- a/front/middleware/before_auth.js
+++ b/front/middleware/before_auth.js
@@ -1,0 +1,6 @@
+export default function ({ store, redirect }) {
+  const isSingedIn = store.state.user.isSignedIn
+  if (isSingedIn) {
+    return redirect('/')
+  }
+}

--- a/front/pages/sign_in.vue
+++ b/front/pages/sign_in.vue
@@ -41,6 +41,8 @@
 
 <script>
 export default {
+  middleware: ['before_auth'],
+
   data() {
     return {
       name: '',

--- a/front/pages/sign_up.vue
+++ b/front/pages/sign_up.vue
@@ -50,6 +50,8 @@
 
 <script>
 export default {
+  middleware: ['before_auth'],
+
   data() {
     return {
       name: '',


### PR DESCRIPTION
## 概要
- 認証前後の状態を判定してリダイレクト処理を走らせるように調整

## 内容
- middleware に記述することでページ読み込み前に本 PR の処理が実行される

## 補足
- トップページの記事一覧は誰でも閲覧できるようにしたいので対象外