### PR TITLE
ログイン前に記事作成ページへ遷移できないように調整

### DIFF
--- a/front/pages/writing_article.vue
+++ b/front/pages/writing_article.vue
@@ -33,6 +33,7 @@
 
 <script>
 export default {
+  middleware: ['authed'],
   data() {
     return {
       id: '',


### PR DESCRIPTION
## 概要
- 実装漏れがあったので調整

## 関連PR
- #49 